### PR TITLE
Fix for issue #6 - Extending CLASSPATH of MPJ node process under Yarn

### DIFF
--- a/src/runtime/starter/MPJAppMaster.java
+++ b/src/runtime/starter/MPJAppMaster.java
@@ -110,6 +110,7 @@ public class MPJAppMaster {
   private int containerCores;
   private int maxCores;
   private int mpjContainerPriority;
+  private String cp ;
   private int allocatedContainers;
   private int completedContainers;
   private List<Container> mpiContainers = new ArrayList<Container>();
@@ -137,6 +138,8 @@ public class MPJAppMaster {
     opts.addOption("containerCores",true,"Specifies mpj containers v-cores");
     opts.addOption("mpjContainerPriority",true,"Specifies the prioirty of" +
                                        "containers running MPI processes");
+    opts.addOption("cp",true,"Added to CLASSPATH in MPJ node " +
+                         "process environment");
     opts.addOption("debugYarn",false,"Specifies the debug flag");
 
   }
@@ -165,6 +168,8 @@ public class MPJAppMaster {
 
        mpjContainerPriority = Integer.parseInt(cliParser.getOptionValue
 						("mpjContainerPriority","0"));
+
+       cp = cliParser.getOptionValue("cp", null) ;
 
        if(cliParser.hasOption("appArgs")){
          appArgs = cliParser.getOptionValues("appArgs");
@@ -382,6 +387,11 @@ public class MPJAppMaster {
     Apps.addToEnvironment(containerEnv,
                           Environment.CLASSPATH.name(),
                           Environment.PWD.$() + File.separator + "*");
+
+    if(cp != null) {
+      Apps.addToEnvironment(containerEnv, Environment.CLASSPATH.name(),
+                            cp, File.pathSeparator);
+    }
   }
 
   

--- a/src/runtime/starter/MPJRun.java
+++ b/src/runtime/starter/MPJRun.java
@@ -100,6 +100,7 @@ public class MPJRun {
   private String amPriority;
   private String mpjContainerPriority;
   private String hdfsFolder;
+  private String cp ;
 
   String machinesFile = DEFAULT_MACHINES_FILE_NAME;
   private int psl = DEFAULT_PROTOCOL_SWITCH_LIMIT;
@@ -274,6 +275,11 @@ public class MPJRun {
       if(hdfsFolder != null){
         commands.add("--hdfsFolder");
         commands.add(hdfsFolder);
+      }
+
+      if(cp != null){
+        commands.add("--cp");
+        commands.add(cp);
       }
 
       //debugYarn flag
@@ -511,6 +517,7 @@ public class MPJRun {
         }
         i++;
       }
+
       else if (args[i].equals("-dport")) {
         D_SER_PORT = new Integer(args[i + 1]).intValue();
         i++;
@@ -552,8 +559,9 @@ public class MPJRun {
       }
 
       else if (args[i].equals("-cp") | args[i].equals("-classpath")) {
+        cp = args[i + 1] ;
         jvmArgs.add("-cp");
-        jvmArgs.add(args[i + 1]);
+        jvmArgs.add(cp);
         i++;
       }
 

--- a/src/runtime/starter/MPJYarnClient.java
+++ b/src/runtime/starter/MPJYarnClient.java
@@ -110,6 +110,7 @@ public class MPJYarnClient {
   private int amPriority;
   private String  mpjContainerPriority; 
   private String hdfsFolder;
+  private String cp ;
   private boolean debugYarn = false;
   private Log logger = null;
   private int SERVER_PORT = 0;
@@ -153,6 +154,8 @@ public class MPJYarnClient {
                                        "containers running MPI processes");
     opts.addOption("hdfsFolder",true,"Specifies the HDFS folder where AM,"+
                          "Wrapper and user code jar files will be uploaded");
+    opts.addOption("cp",true,"Added to CLASSPATH in MPJ node " +
+                         "process environment");
     opts.addOption("debugYarn",false,"Specifies the debug flag");
   }
   
@@ -195,6 +198,8 @@ public class MPJYarnClient {
                                              ("mpjContainerPriority","0");
       
       hdfsFolder = cliParser.getOptionValue("hdfsFolder","/");
+
+      cp = cliParser.getOptionValue("cp", null) ;
 
       if(cliParser.hasOption("appArgs")){  
         appArgs = cliParser.getOptionValues("appArgs");
@@ -371,6 +376,10 @@ public class MPJYarnClient {
       commands.add(containerMem);
       commands.add("--containerCores");   
       commands.add(containerCores);
+      if(cp != null) {
+        commands.add("--cp");   
+        commands.add(cp);
+      }
       
       if(debugYarn){
         commands.add("--debugYarn");


### PR DESCRIPTION
Value of -cp if it exists passed from MPJRun to MPJYarnClient in --cp argument, then forwarded similarly to MPJAppMaster.  Latter uses it to extend classpath in setupEnv().

Fixes issue #6.